### PR TITLE
fix: change cron schedule to daily for Vercel Hobby plan

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/cron/reminders",
-      "schedule": "*/5 * * * *"
+      "schedule": "0 9 * * *"
     }
   ]
 }


### PR DESCRIPTION
- Changed from */5 * * * * (every 5 min) to 0 9 * * * (daily 9 AM UTC)
- Hobby accounts limited to 1 cron per day
- Upgrade to Pro plan if more frequent cron needed